### PR TITLE
Checkpoint improvements in startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 *.iml
 .gradle
 /build
+*.pyc

--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ helm install -f helm/aws-dev.yaml ...
 ## TODO
 ### scylla
 - get rid of the start-scylla script -- do config map and injection instead
-- Fix the background tasks method of start -- maybe two containers...
+  - also ensure that the main process (group) can catch a SIGTERM for gracefull shutdown
+  - fix the background tasks method of start -- maybe two containers...
 - Add in liveness checks for health check
 - Smarter sparse list for seed protocol (or just new a new provider)
 - There seems to be some root file system writes on scylladb during large ingest
 - **Intermittent**: A new cluster doesn't always seem to have all nodes join.  Feels like something with the dns entries not yet showing up...
   - really what is needed here is kairos shouldn't interfere with scylla while the first nodes are joining
   - workaround is --set replicaCount=0 to stop kairos from starting, first and then upgrade template with target replicaCount
-- Need to use the Ec2Snitch or something so that rack is to the AZ
-- Need pod shutdown command to do graceful shutdown of scylladb (catch signal, etc)
 - Evaluate inter-node compression settings
 
 ### kairos

--- a/docker-scylladb/start-scylla
+++ b/docker-scylladb/start-scylla
@@ -4,6 +4,9 @@ ps -ewwf
 
 . /etc/default/scylla-server
 
+echo "commandline------"
+echo $@
+echo "-------"
 echo "environment------"
 env | sort
 echo "-------"
@@ -75,6 +78,8 @@ sed -i "s/listen_address: localhost/listen_address: $SCYLLA_LISTEN_ADDRESS/g" /e
 if [ x"$SCYLLA_BROADCAST_ADDRESS" != "x" ];then
 	sed -i "s/.*broadcast_address:.*/broadcast_address: $SCYLLA_BROADCAST_ADDRESS/g" /etc/scylla/scylla.yaml
 fi
+
+export SCYLLA_HOME SCYLLA_CONF
 
 # TODO running this and JMX in the background is probably not right -- pod won't terminate if scylla terminates for example...
 /usr/bin/scylla $@ --options-file /etc/scylla/scylla.yaml --listen-address $SCYLLA_LISTEN_ADDRESS --rpc-address $SCYLLA_LISTEN_ADDRESS --network-stack posix &

--- a/helm/aws-dev.yaml
+++ b/helm/aws-dev.yaml
@@ -26,8 +26,7 @@ scylladb:
     overprovisioned: 0
     cpu: 2
     memory: 2G
-#   endpointSnitch: Ec2Snitch  TODO https://github.com/scylladb/scylla/issues/2980
-    endpointSnitch: RackInferringSnitch
+    endpointSnitch: Ec2Snitch
 
   replicaCount: 6
 

--- a/helm/aws-prd.yaml
+++ b/helm/aws-prd.yaml
@@ -26,8 +26,7 @@ scylladb:
     overprovisioned: 0
     cpu: 16
     memory: 16G
-#   endpointSnitch: Ec2Snitch  TODO https://github.com/scylladb/scylla/issues/2980
-    endpointSnitch: RackInferringSnitch
+    endpointSnitch: Ec2Snitch
 
   replicaCount: 9
 

--- a/helm/kairosdb/Chart.yaml
+++ b/helm/kairosdb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for KairosDB orchestrator
 name: kairosdb
-version: 0.5.7
+version: 0.6.2

--- a/helm/kairosdb/charts/scylladb/Chart.yaml
+++ b/helm/kairosdb/charts/scylladb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: scylladb
-version: 0.5.7
+version: 0.6.2

--- a/helm/kairosdb/charts/scylladb/templates/statefulset.yaml
+++ b/helm/kairosdb/charts/scylladb/templates/statefulset.yaml
@@ -62,9 +62,11 @@ spec:
           - --endpoint-snitch
           - {{ .Values.config.endpointSnitch | quote }}
           {{- end }}
+{{- if .Values.persistence.size }}
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/scylla
+{{- end }}
 #        livenessProbe:
 #          exec:
 #            command:
@@ -79,6 +81,7 @@ spec:
 #          timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.persistence.size }}
   volumeClaimTemplates:
   - metadata:
       name: datadir
@@ -92,3 +95,4 @@ spec:
       {{- if .Values.persistence.storageClass }}
       storageClassName: {{ .Values.persistence.storageClass | quote }}
       {{- end }}
+{{- end }}

--- a/helm/kairosdb/charts/scylladb/values.yaml
+++ b/helm/kairosdb/charts/scylladb/values.yaml
@@ -38,7 +38,8 @@ persistence:
   ##
   # storageClass:
   accessMode: ReadWriteOnce
-  size: 1Gi
+  # if set, a PVC will also be allocated
+  # size: 1Gi
 
 global:
   image:

--- a/helm/kairosdb/values.yaml
+++ b/helm/kairosdb/values.yaml
@@ -30,4 +30,4 @@ global:
   image:
     repositoryPrefix:
     pullPolicy: IfNotPresent
-    tag: v0.6.2
+    tag: v0.6.3

--- a/helm/kairosdb/values.yaml
+++ b/helm/kairosdb/values.yaml
@@ -30,4 +30,4 @@ global:
   image:
     repositoryPrefix:
     pullPolicy: IfNotPresent
-    tag: v0.5.7
+    tag: v0.6.2


### PR DESCRIPTION
 - enable Ec2Snitch for when running in AWS
 - in particular, export SCYLLA_CONF: needed by Ec2Snitch
 - stateful set will only allocate PVC if size specified (makes minikube easier)